### PR TITLE
Patch 2 alternate

### DIFF
--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -71,9 +71,13 @@ module Analytical
     # These methods return the javascript that should be inserted into each section of your layout
     #
     def head_prepend_javascript
+      [init_javascript(:head_prepend), tracking_javascript(:head_prepend)].delete_if{|s| s.blank?}.join("\n")
+    end
+
+    def head_append_javascript
       js = [
-        init_javascript(:head_prepend),
-        tracking_javascript(:head_prepend),
+        init_javascript(:head_append),
+        tracking_javascript(:head_append),
       ]
 
       if options[:javascript_helpers]
@@ -86,10 +90,6 @@ module Analytical
       end
 
       js.delete_if{|s| s.blank?}.join("\n")
-    end
-
-    def head_append_javascript
-      [init_javascript(:head_append), tracking_javascript(:head_append)].delete_if{|s| s.blank?}.join("\n")
     end
 
     alias_method :head_javascript, :head_append_javascript

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -71,13 +71,9 @@ module Analytical
     # These methods return the javascript that should be inserted into each section of your layout
     #
     def head_prepend_javascript
-      [init_javascript(:head_prepend), tracking_javascript(:head_prepend)].delete_if{|s| s.blank?}.join("\n")
-    end
-
-    def head_append_javascript
       js = [
-        init_javascript(:head_append),
-        tracking_javascript(:head_append),
+        init_javascript(:head_prepend),
+        tracking_javascript(:head_prepend),
       ]
 
       if options[:javascript_helpers]
@@ -90,6 +86,10 @@ module Analytical
       end
 
       js.delete_if{|s| s.blank?}.join("\n")
+    end
+
+    def head_append_javascript
+      [init_javascript(:head_append), tracking_javascript(:head_append)].delete_if{|s| s.blank?}.join("\n")
     end
 
     alias_method :head_javascript, :head_append_javascript

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -115,8 +115,11 @@ module Analytical
         commands += m.process_queued_commands if m.init_location?(location) || m.initialized
       end
       commands = commands.delete_if{|c| c.blank? || c.empty?}
+      ready_module = options[:ready_module]
       unless commands.empty?
+        commands.unshift "#{ready_module}.ready(function(){" if ready_module
         commands.unshift "<script type='text/javascript'>"
+        commands << "});" if ready_module
         commands << "</script>"
       end
       commands.join("\n")

--- a/lib/analytical/modules/console.rb
+++ b/lib/analytical/modules/console.rb
@@ -57,6 +57,13 @@ module Analytical
         HERE
       end
 
+      def person(data)
+        check_for_console <<-HERE
+        console.log("Analytical Person: ");
+        console.log(#{data.to_json});
+        HERE
+      end
+
       private
 
       CONSOLE_JS_ESCAPE_MAP = {

--- a/lib/analytical/modules/google_universal.rb
+++ b/lib/analytical/modules/google_universal.rb
@@ -31,7 +31,6 @@ module Analytical
         data = args.first || {}
         data = data[:value] if data.is_a?(Hash)
         data_string = !data.nil? ? ", #{data}" : ""
-        "_gaq.push(['_trackEvent', \"Event\", \"#{name}\"" + data_string + "]);"
         "ga('send', 'event', \"Event\", \"#{name}\"" + data_string + ");"
       end
     end

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -41,7 +41,7 @@ module Analytical
             'track_forms','register','register_once','unregister','identify','alias','name_tag',
             'set_config','people.set','people.increment','people.track_charge','people.append'];
             for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
-            var config = { track_pageview: #{options.fetch(:track_pageview, true)} };
+            var config = #{options.reject { |k,v| k == :key }.to_json};
             mixpanel.init("#{options[:key]}", config);
           </script>
           HTML

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -49,7 +49,7 @@ module Analytical
         end
       end
 
-      
+
       # Examples:
       #     analytical.track(url_viewed)
       #     analytical.track(url_viewed, 'page name' => @page_title)
@@ -59,7 +59,7 @@ module Analytical
       # named 'page viewed'. This follows a recommendation in the Mixpanel docs for
       # minimizing the number of distinct events you log, thus keeping your event data uncluttered.
       #
-      # The url is followed by a Hash parameter that contains any other custom properties 
+      # The url is followed by a Hash parameter that contains any other custom properties
       # you want logged along with the pageview event. The following Hash keys get special treatment:
       # * :callback => String representing javascript function to callback
       # * :event => overrides the default event name for pageviews
@@ -67,7 +67,7 @@ module Analytical
       #
       # Mixpanel docs also recommend specifying a 'page name' property when tracking pageviews.
       #
-      # To turn off pageview tracking for Mixpanel entirely, initialize analytical as follows: 
+      # To turn off pageview tracking for Mixpanel entirely, initialize analytical as follows:
       #        analytical( ... mixpanel: { key: ENV['MIXPANEL_KEY'], track_pageview: false } ... )
       def track(*args)
         return if args.empty?
@@ -79,7 +79,7 @@ module Analytical
           properties[:url] = url
           # Docs recommend: mixpanel.track('page viewed', {'page name' : document.title, 'url' : window.location.pathname});
           %(mixpanel.track("#{event}", #{properties.to_json}, #{callback});)
-        end          
+        end
       end
 
       # Used to set "Super Properties" - http://mixpanel.com/api/docs/guides/super-properties
@@ -105,11 +105,11 @@ module Analytical
       def event(name, attributes = {})
         %(mixpanel.track("#{name}", #{attributes.to_json});)
       end
-      
+
       def person(attributes = {})
         %(mixpanel.people.set(#{attributes.to_json});)
       end
-      
+
       def revenue(charge, attributes = {})
         %(mixpanel.people.track_charge(#{charge}, #{attributes.to_json});)
       end

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -5,7 +5,7 @@ module Analytical
 
       def initialize(options={})
         super
-        @tracking_command_location = :head_prepend
+        @tracking_command_location = :head_append
       end
 
       # Mixpanel-specific queueing behavior, overrides Base#queue

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -32,17 +32,19 @@ module Analytical
           js = <<-HTML
           <!-- Analytical Init: Mixpanel -->
           <script type="text/javascript">
-            (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
-            b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-            '//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';d=c.getElementsByTagName("script")[0];
-            d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
-            var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
-            Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
-            f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
-            'track_forms','register','register_once','unregister','identify','alias','name_tag',
-            'set_config','people.set','people.increment','people.track_charge','people.append'];
-            for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
-            mixpanel.init("#{options[:key]}", #{config});
+            if(!(typeof analytics !== 'undefined' && typeof analytics.Integrations !== 'undefined' && analytics.Integrations.hasOwnProperty("Mixpanel"))) {
+              (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
+              b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
+              '//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';d=c.getElementsByTagName("script")[0];
+              d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
+              var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
+              Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
+              f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
+              'track_forms','register','register_once','unregister','identify','alias','name_tag',
+              'set_config','people.set','people.increment','people.track_charge','people.append'];
+              for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
+              mixpanel.init("#{options[:key]}", #{config});
+            }
           </script>
           HTML
           js

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -5,7 +5,7 @@ module Analytical
 
       def initialize(options={})
         super
-        @tracking_command_location = :body_append
+        @tracking_command_location = :head_prepend
       end
 
       # Mixpanel-specific queueing behavior, overrides Base#queue

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -41,7 +41,7 @@ module Analytical
             'track_forms','register','register_once','unregister','identify','alias','name_tag',
             'set_config','people.set','people.increment','people.track_charge','people.append'];
             for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
-            var config = #{options.reject { |k,v| k == :key }.to_json};
+            var config = #{options[:mixpanel].reject { |k,v| k == :key }.to_json};
             mixpanel.init("#{options[:key]}", config);
           </script>
           HTML

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -28,6 +28,7 @@ module Analytical
 
       def init_javascript(location)
         init_location(location) do
+          config = options[:mixpanel] ? options[:mixpanel].reject { |k,v| k == :key }.to_json : {}.to_json
           js = <<-HTML
           <!-- Analytical Init: Mixpanel -->
           <script type="text/javascript">
@@ -41,8 +42,7 @@ module Analytical
             'track_forms','register','register_once','unregister','identify','alias','name_tag',
             'set_config','people.set','people.increment','people.track_charge','people.append'];
             for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
-            var config = #{options[:mixpanel].reject { |k,v| k == :key }.to_json};
-            mixpanel.init("#{options[:key]}", config);
+            mixpanel.init("#{options[:key]}", "#{config}");
           </script>
           HTML
           js

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -42,7 +42,7 @@ module Analytical
             'track_forms','register','register_once','unregister','identify','alias','name_tag',
             'set_config','people.set','people.increment','people.track_charge','people.append'];
             for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
-            mixpanel.init("#{options[:key]}", "#{config}");
+            mixpanel.init("#{options[:key]}", #{config});
           </script>
           HTML
           js


### PR DESCRIPTION
* Only initialize mix panel if segment is not defined, or if the segment mix panel integration is not turned on
* Allow for commands to be written to page within a ready block. The name of the module the ready function will be called from will be pulled from the analytical call like:
analytical modules: [:mixpanel, :console],
    use_session_store: true,
    ready_module: 'analytics',
    disable_if: -> (controller) { controller.disable_analytics? }