### PR TITLE
Patch 2 alternate

### DIFF
--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -115,8 +115,11 @@ module Analytical
         commands += m.process_queued_commands if m.init_location?(location) || m.initialized
       end
       commands = commands.delete_if{|c| c.blank? || c.empty?}
+      ready_module = options[:ready_module]
       unless commands.empty?
+        commands.unshift "#{ready_module}.ready(function(){" if ready_module
         commands.unshift "<script type='text/javascript'>"
+        commands << "});" if ready_module
         commands << "</script>"
       end
       commands.join("\n")

--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -32,17 +32,19 @@ module Analytical
           js = <<-HTML
           <!-- Analytical Init: Mixpanel -->
           <script type="text/javascript">
-            (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
-            b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-            '//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';d=c.getElementsByTagName("script")[0];
-            d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
-            var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
-            Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
-            f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
-            'track_forms','register','register_once','unregister','identify','alias','name_tag',
-            'set_config','people.set','people.increment','people.track_charge','people.append'];
-            for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
-            mixpanel.init("#{options[:key]}", #{config});
+            if(!(typeof analytics !== 'undefined' && typeof analytics.Integrations !== 'undefined' && analytics.Integrations.hasOwnProperty("Mixpanel"))) {
+              (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
+              b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
+              '//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';d=c.getElementsByTagName("script")[0];
+              d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
+              var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
+              Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
+              f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
+              'track_forms','register','register_once','unregister','identify','alias','name_tag',
+              'set_config','people.set','people.increment','people.track_charge','people.append'];
+              for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
+              mixpanel.init("#{options[:key]}", #{config});
+            }
           </script>
           HTML
           js


### PR DESCRIPTION
* Only initialize mix panel if segment is not defined, or if the segment mix panel integration is not turned on
* Allow for commands to be written to page within a ready block. The name of the module the ready function will be called from will be pulled from the analytical call like:
analytical modules: [:mixpanel, :console],
    use_session_store: true,
    ready_module: 'analytics',
    disable_if: -> (controller) { controller.disable_analytics? }

I think this is a better approach than #1 - the reason being is that the initialization of mix panel in this case is dynamically tied to if the Segment integration is enabled.  Otherwise we have to commit, and deploy in order for the enable/disable the mix panel integration which would most likely result in some javascript errors in the time between enabling/disabling in Segment, and deploying the new commits.